### PR TITLE
Add photo placeholder and ‘新增照片’ button; stub `onPickImage`

### DIFF
--- a/app/components/ExerciseCard.tsx
+++ b/app/components/ExerciseCard.tsx
@@ -65,12 +65,16 @@ export default function ExerciseCard({
       />
 
       <View style={styles.imageRow}>
-        <Image
-          source={value.imageUri ? { uri: value.imageUri } : placeholderImage}
-          style={styles.image}
-        />
+        {value.imageUri ? (
+          <Image source={{ uri: value.imageUri }} style={styles.image} />
+        ) : (
+          <View style={styles.placeholder}>
+            <Image source={placeholderImage} style={styles.placeholderImage} />
+            <Text style={styles.placeholderText}>尚未新增照片</Text>
+          </View>
+        )}
         <TouchableOpacity onPress={onPickImage} style={styles.imageButton}>
-          <Text style={styles.imageButtonText}>選擇照片</Text>
+          <Text style={styles.imageButtonText}>新增照片</Text>
         </TouchableOpacity>
       </View>
 
@@ -186,6 +190,26 @@ const styles = StyleSheet.create({
     height: 72,
     borderRadius: 12,
     backgroundColor: "#F3F4F6",
+  },
+  placeholder: {
+    width: 72,
+    height: 72,
+    borderRadius: 12,
+    backgroundColor: "#F3F4F6",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 4,
+    padding: 6,
+  },
+  placeholderImage: {
+    width: 32,
+    height: 32,
+    opacity: 0.8,
+  },
+  placeholderText: {
+    fontSize: 10,
+    color: "#6B7280",
+    textAlign: "center",
   },
   imageButton: {
     paddingVertical: 10,

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Alert, SafeAreaView, StyleSheet, View } from "react-native";
+import { SafeAreaView, StyleSheet, View } from "react-native";
 import ExerciseCard, { ExerciseValue } from "./components/ExerciseCard";
 
 const UNIT_OPTIONS = ["公斤", "磅", "次數"];
@@ -20,7 +20,7 @@ export default function Index() {
         <ExerciseCard
           value={exercise}
           onChange={setExercise}
-          onPickImage={() => Alert.alert("選擇照片", "之後可串接相簿選擇")}
+          onPickImage={() => console.log("pick image")}
           unitOptions={UNIT_OPTIONS}
         />
       </View>


### PR DESCRIPTION
### Motivation
- Provide a clear UI when no exercise photo is set by showing a placeholder and hint text so users know they can add a photo. 
- Rename the photo action to `新增照片` to better reflect the add-photo flow in the card. 
- Leave an easy-to-replace stub for image picking so future integration with `expo-image-picker` or `react-native-image-picker` is trivial. 

### Description
- Update `app/components/ExerciseCard.tsx` to render a placeholder block (image + helper text) when `value.imageUri` is falsy and add `placeholder`, `placeholderImage`, and `placeholderText` styles. 
- Change the image action label from `選擇照片` to `新增照片` on the card button. 
- Update `app/index.tsx` to replace the previous `Alert.alert(...)` callback with a stub `onPickImage={() => console.log("pick image")}` and remove the now-unused `Alert` import. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954c25d4b5883218176f52d4702903f)