### PR TITLE
Make ExerciseCard unit selection controlled via props

### DIFF
--- a/app/components/ExerciseCard.tsx
+++ b/app/components/ExerciseCard.tsx
@@ -18,7 +18,6 @@ export type ExerciseValue = {
   sets: string;
   reps: string;
   weight: string;
-  unit: string;
 };
 
 type ExerciseCardProps = {
@@ -26,6 +25,8 @@ type ExerciseCardProps = {
   onChange: (nextValue: ExerciseValue) => void;
   onPickImage: () => void;
   unitOptions: string[];
+  unit: string;
+  onUnitChange: (nextUnit: string) => void;
 };
 
 export default function ExerciseCard({
@@ -33,16 +34,18 @@ export default function ExerciseCard({
   onChange,
   onPickImage,
   unitOptions,
+  unit,
+  onUnitChange,
 }: ExerciseCardProps) {
   const [isUnitModalVisible, setUnitModalVisible] = useState(false);
 
   const selectedUnitLabel = useMemo(() => {
-    if (value.unit) {
-      return value.unit;
+    if (unit) {
+      return unit;
     }
 
     return unitOptions[0] ?? "選擇單位";
-  }, [unitOptions, value.unit]);
+  }, [unit, unitOptions]);
 
   const updateField = <Key extends keyof ExerciseValue>(
     key: Key,
@@ -139,7 +142,7 @@ export default function ExerciseCard({
               <TouchableOpacity
                 key={option}
                 onPress={() => {
-                  updateField("unit", option);
+                  onUnitChange(option);
                   setUnitModalVisible(false);
                 }}
                 style={styles.modalOption}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -11,8 +11,8 @@ export default function Index() {
     sets: "4",
     reps: "8",
     weight: "60",
-    unit: UNIT_OPTIONS[0],
   });
+  const [unit, setUnit] = useState(UNIT_OPTIONS[0]);
 
   return (
     <SafeAreaView style={styles.container}>
@@ -22,6 +22,8 @@ export default function Index() {
           onChange={setExercise}
           onPickImage={() => console.log("pick image")}
           unitOptions={UNIT_OPTIONS}
+          unit={unit}
+          onUnitChange={setUnit}
         />
       </View>
     </SafeAreaView>


### PR DESCRIPTION
### Motivation
- Decouple unit selection from the exercise data so the parent can control unit state centrally.
- Allow `index.tsx` to manage unit selection and keep `ExerciseValue` focused on exercise fields.

### Description
- Add `unit: string` and `onUnitChange: (nextUnit: string) => void` props to `ExerciseCard` and use `unit` to determine the displayed label.
- Replace internal updates to `ExerciseValue.unit` with calls to `onUnitChange` when a unit is selected from the modal.
- Remove the `unit` field from the `ExerciseValue` type and add a separate `unit` state in `app/index.tsx` passed into `ExerciseCard` as `unit`/`onUnitChange`.
- Files changed: `app/components/ExerciseCard.tsx` and `app/index.tsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954c45e3b1c8321bcde991474570568)