### PR TITLE
Split ExerciseCard state into individual hooks in index

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -5,21 +5,36 @@ import ExerciseCard, { ExerciseValue } from "./components/ExerciseCard";
 const UNIT_OPTIONS = ["公斤", "磅", "次數"];
 
 export default function Index() {
-  const [exercise, setExercise] = useState<ExerciseValue>({
-    name: "深蹲",
-    imageUri: null,
-    sets: "4",
-    reps: "8",
-    weight: "60",
-  });
+  const [name, setName] = useState("深蹲");
+  const [sets, setSets] = useState("4");
+  const [reps, setReps] = useState("8");
+  const [weight, setWeight] = useState("60");
+  const [imageUri, setImageUri] = useState<string | null>(null);
   const [unit, setUnit] = useState(UNIT_OPTIONS[0]);
+
+  // TODO: replace with an array of cards when supporting multiple exercises.
+  const exerciseValue: ExerciseValue = {
+    name,
+    imageUri,
+    sets,
+    reps,
+    weight,
+  };
+
+  const handleExerciseChange = (nextValue: ExerciseValue) => {
+    setName(nextValue.name);
+    setSets(nextValue.sets);
+    setReps(nextValue.reps);
+    setWeight(nextValue.weight);
+    setImageUri(nextValue.imageUri ?? null);
+  };
 
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.cardWrapper}>
         <ExerciseCard
-          value={exercise}
-          onChange={setExercise}
+          value={exerciseValue}
+          onChange={handleExerciseChange}
           onPickImage={() => console.log("pick image")}
           unitOptions={UNIT_OPTIONS}
           unit={unit}


### PR DESCRIPTION
### Motivation
- Make each exercise field independently controllable by using separate state hooks instead of a single object.
- Ensure `ExerciseCard` receives up-to-date values and a single change handler while keeping future support for multiple cards in mind.

### Description
- Replace the single `useState<ExerciseValue>` object in `app/index.tsx` with individual hooks: `name`, `sets`, `reps`, `weight`, and `imageUri` using `useState`.
- Derive a combined `exerciseValue: ExerciseValue` and provide a `handleExerciseChange` function that updates the individual hooks from the incoming `ExerciseValue`.
- Update the `ExerciseCard` props to pass `value={exerciseValue}` and `onChange={handleExerciseChange}`.
- Add a `// TODO` note to `app/index.tsx` to indicate future migration to an array of cards for multi-exercise support.

### Testing
- No automated tests were run for this change.
- Manual smoke verification: app builds and `ExerciseCard` renders with the derived values (manual run, not automated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954c64da5c08321abd9c3a41e1af5ac)