### PR TITLE
Add dynamic set rows and move unit selector to card header

### DIFF
--- a/app/components/ExerciseCard.tsx
+++ b/app/components/ExerciseCard.tsx
@@ -15,7 +15,11 @@ const placeholderImage = require("../../assets/images/react-logo.png");
 export type ExerciseValue = {
   name: string;
   imageUri?: string | null;
-  sets: string;
+  setRows: SetRow[];
+};
+
+type SetRow = {
+  id: string;
   reps: string;
   weight: string;
 };
@@ -57,9 +61,35 @@ export default function ExerciseCard({
     });
   };
 
+  const handleAddSet = () => {
+    const newSet: SetRow = {
+      id: `set-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      reps: "",
+      weight: "",
+    };
+
+    updateField("setRows", [...value.setRows, newSet]);
+  };
+
+  const updateSetRow = (id: string, field: "reps" | "weight", next: string) => {
+    const nextRows = value.setRows.map((row) =>
+      row.id === id ? { ...row, [field]: next } : row
+    );
+
+    updateField("setRows", nextRows);
+  };
+
   return (
     <View style={styles.card}>
-      <Text style={styles.title}>訓練內容</Text>
+      <View style={styles.header}>
+        <Text style={styles.title}>訓練內容</Text>
+        <Pressable
+          onPress={() => setUnitModalVisible(true)}
+          style={styles.unitBadge}
+        >
+          <Text style={styles.unitBadgeText}>{selectedUnitLabel}</Text>
+        </Pressable>
+      </View>
       <TextInput
         value={value.name}
         onChangeText={(text) => updateField("name", text)}
@@ -81,50 +111,40 @@ export default function ExerciseCard({
         </TouchableOpacity>
       </View>
 
-      <View style={styles.row}>
-        <View style={styles.field}>
-          <Text style={styles.label}>組數</Text>
-          <TextInput
-            value={value.sets}
-            onChangeText={(text) => updateField("sets", text)}
-            placeholder="0"
-            keyboardType="numeric"
-            style={styles.input}
-          />
-        </View>
-        <View style={styles.field}>
-          <Text style={styles.label}>次數</Text>
-          <TextInput
-            value={value.reps}
-            onChangeText={(text) => updateField("reps", text)}
-            placeholder="0"
-            keyboardType="numeric"
-            style={styles.input}
-          />
-        </View>
+      <View style={styles.setHeader}>
+        <Text style={styles.sectionTitle}>每組紀錄</Text>
+        <TouchableOpacity onPress={handleAddSet} style={styles.addButton}>
+          <Text style={styles.addButtonText}>+ 新增一列</Text>
+        </TouchableOpacity>
       </View>
 
-      <View style={styles.row}>
-        <View style={styles.field}>
-          <Text style={styles.label}>重量</Text>
-          <TextInput
-            value={value.weight}
-            onChangeText={(text) => updateField("weight", text)}
-            placeholder="0"
-            keyboardType="numeric"
-            style={styles.input}
-          />
+      {value.setRows.map((row, index) => (
+        <View key={row.id} style={styles.setRow}>
+          <View style={styles.setIndex}>
+            <Text style={styles.setIndexText}>{index + 1}</Text>
+          </View>
+          <View style={styles.field}>
+            <Text style={styles.label}>次數</Text>
+            <TextInput
+              value={row.reps}
+              onChangeText={(text) => updateSetRow(row.id, "reps", text)}
+              placeholder="0"
+              keyboardType="numeric"
+              style={styles.input}
+            />
+          </View>
+          <View style={styles.field}>
+            <Text style={styles.label}>重量</Text>
+            <TextInput
+              value={row.weight}
+              onChangeText={(text) => updateSetRow(row.id, "weight", text)}
+              placeholder="0"
+              keyboardType="numeric"
+              style={styles.input}
+            />
+          </View>
         </View>
-        <View style={styles.field}>
-          <Text style={styles.label}>單位</Text>
-          <Pressable
-            onPress={() => setUnitModalVisible(true)}
-            style={styles.dropdown}
-          >
-            <Text style={styles.dropdownText}>{selectedUnitLabel}</Text>
-          </Pressable>
-        </View>
-      </View>
+      ))}
 
       <Modal
         visible={isUnitModalVisible}
@@ -169,10 +189,26 @@ const styles = StyleSheet.create({
     elevation: 3,
     gap: 12,
   },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
   title: {
     fontSize: 18,
     fontWeight: "600",
     color: "#1F2937",
+  },
+  unitBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: "#E0E7FF",
+  },
+  unitBadgeText: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#4338CA",
   },
   input: {
     borderWidth: 1,
@@ -225,10 +261,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: "600",
   },
-  row: {
-    flexDirection: "row",
-    gap: 12,
-  },
   field: {
     flex: 1,
     gap: 8,
@@ -237,17 +269,50 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: "#6B7280",
   },
-  dropdown: {
-    borderWidth: 1,
-    borderColor: "#E5E7EB",
-    borderRadius: 10,
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-    backgroundColor: "#F9FAFB",
-  },
-  dropdownText: {
+  sectionTitle: {
     fontSize: 14,
+    fontWeight: "600",
     color: "#111827",
+  },
+  setHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginTop: 4,
+  },
+  addButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: "#111827",
+  },
+  addButtonText: {
+    color: "#FFFFFF",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  setRow: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    gap: 12,
+    backgroundColor: "#F9FAFB",
+    borderRadius: 12,
+    padding: 12,
+    marginTop: 8,
+  },
+  setIndex: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    backgroundColor: "#E5E7EB",
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 20,
+  },
+  setIndexText: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#4B5563",
   },
   modalBackdrop: {
     flex: 1,

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -2,13 +2,13 @@ import { useState } from "react";
 import { SafeAreaView, StyleSheet, View } from "react-native";
 import ExerciseCard, { ExerciseValue } from "./components/ExerciseCard";
 
-const UNIT_OPTIONS = ["公斤", "磅", "次數"];
+const UNIT_OPTIONS = ["公斤", "磅"];
 
 export default function Index() {
   const [name, setName] = useState("深蹲");
-  const [sets, setSets] = useState("4");
-  const [reps, setReps] = useState("8");
-  const [weight, setWeight] = useState("60");
+  const [setRows, setSetRows] = useState([
+    { id: "set-1", reps: "8", weight: "60" },
+  ]);
   const [imageUri, setImageUri] = useState<string | null>(null);
   const [unit, setUnit] = useState(UNIT_OPTIONS[0]);
 
@@ -16,16 +16,12 @@ export default function Index() {
   const exerciseValue: ExerciseValue = {
     name,
     imageUri,
-    sets,
-    reps,
-    weight,
+    setRows,
   };
 
   const handleExerciseChange = (nextValue: ExerciseValue) => {
     setName(nextValue.name);
-    setSets(nextValue.sets);
-    setReps(nextValue.reps);
-    setWeight(nextValue.weight);
+    setSetRows(nextValue.setRows);
     setImageUri(nextValue.imageUri ?? null);
   };
 


### PR DESCRIPTION
### Motivation

- Allow the exercise card to add per-set rows via a button so each row can capture `次數` and `重量` independently.
- Remove the old single "組數" field and make units per-card (badge in the header) so weight units are clearer and consistent.
- Store multiple sets as a structured collection instead of separate flat fields for better UI and state handling.

### Description

- Replace flat fields with `setRows: SetRow[]` and add a `SetRow` type in `app/components/ExerciseCard.tsx` to represent individual set rows.
- Add `handleAddSet` and `updateSetRow` functions and a `+ 新增一列` control to append and edit set rows in `ExerciseCard` UI.
- Move the unit selector into the card header as a badge with modal options and limit `UNIT_OPTIONS` to `[`公斤`, `磅`]` in `app/index.tsx`.
- Update `app/index.tsx` to use `setRows` state and to pass the new `ExerciseValue` shape to `ExerciseCard`.

### Testing

- Ran `npm run web -- --port 19006` (Expo web start) to validate the UI, but it failed with a `fetch failed` error during startup.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954bfac287c8321af8356ebeff5b6be)